### PR TITLE
[!] move metric batching to sinks from the gatherer

### DIFF
--- a/src/config/cmdparser.go
+++ b/src/config/cmdparser.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -66,7 +68,7 @@ type Options struct {
 	Logging                      LoggingOpts    `group:"Logging" mapstructure:"Logging"`
 	WebUI                        WebUIOpts      `group:"WebUI" mapstructure:"WebUI"`
 	Start                        StartOpts      `group:"Start" mapstructure:"Start"`
-	BatchingDelayMs              int64          `long:"batching-delay-ms" mapstructure:"batching-delay-ms" description:"Max milliseconds to wait for a batched metrics flush. [Default: 250]" default:"250" env:"PW3_BATCHING_MAX_DELAY_MS"`
+	BatchingDelay                time.Duration  `long:"batching-delay" mapstructure:"batching-delay" description:"Max milliseconds to wait for a batched metrics flush. [Default: 250ms]" default:"250ms" env:"PW3_BATCHING_MAX_DELAY"`
 	AdHocConnString              string         `long:"adhoc-conn-str" mapstructure:"adhoc-conn-str" description:"Ad-hoc mode: monitor a single Postgres DB specified by a standard Libpq connection string" env:"PW3_ADHOC_CONN_STR"`
 	AdHocDBType                  string         `long:"adhoc-dbtype" mapstructure:"adhoc-dbtype" description:"Ad-hoc mode: postgres|postgres-continuous-discovery" default:"postgres" env:"PW3_ADHOC_DBTYPE"`
 	AdHocConfig                  string         `long:"adhoc-config" mapstructure:"adhoc-config" description:"Ad-hoc mode: a preset config name or a custom JSON config" env:"PW3_ADHOC_CONFIG"`

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	flags "github.com/jessevdk/go-flags"
@@ -82,7 +83,7 @@ func validateConfig(c *Options) error {
 		return err
 	}
 	// validate that input is boolean is set
-	if c.BatchingDelayMs < 0 || c.BatchingDelayMs > 3600000 {
+	if c.BatchingDelay < 0 || c.BatchingDelay > time.Hour {
 		return errors.New("--batching-delay-ms must be between 0 and 3600000")
 	}
 

--- a/src/log/log.go
+++ b/src/log/log.go
@@ -57,7 +57,7 @@ func getLogFileFormatter(opts config.LoggingOpts) logrus.Formatter {
 // Init creates logging facilities for the application
 func Init(opts config.LoggingOpts) LoggerHookerIface {
 	var err error
-	l := logger{logrus.New(), NewHook(context.Background(), opts.LogLevel)}
+	l := logger{logrus.New(), NewBrokerHook(context.Background(), opts.LogLevel)}
 	l.AddHook(l.BrokerHook)
 	l.Out = os.Stdout
 	if opts.LogFile > "" {

--- a/src/log/log_broker_hook.go
+++ b/src/log/log_broker_hook.go
@@ -29,8 +29,8 @@ type BrokerHook struct {
 const cacheLimit = 512
 const highLoadLimit = 200 * time.Millisecond
 
-// NewHook creates a LogHook to be added to an instance of logger
-func NewHook(ctx context.Context, level string) *BrokerHook {
+// NewBrokerHook creates a LogHook to be added to an instance of logger
+func NewBrokerHook(ctx context.Context, level string) *BrokerHook {
 	l := &BrokerHook{
 		highLoadTimeout: highLoadLimit,
 		input:           make(chan *logrus.Entry, cacheLimit),


### PR DESCRIPTION
Not every sink requires batching, e.g. Prometheus, plain files. From now writer implementation is responsible for batching of metric data.

`[*]` rename `BatchingDelayMs` to `BatchingDelay` and allow duration format 
`[*]` remove `MetricsBatcher()`
`[+]` implement batch writes in `sinks.PostgresWriter`