### PR TITLE
[*] use `Metric` term for definition and `Measurement` for data gathered

### DIFF
--- a/src/logparse.go
+++ b/src/logparse.go
@@ -84,8 +84,8 @@ func getFileWithNextModTimestamp(dbUniqueName, logsGlobPath, currentFile string)
 }
 
 // 1. add zero counts for severity levels that didn't have any occurrences in the log
-func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]int64, mdb MonitoredDatabase) []metrics.MetricStoreMessage {
-	allSeverityCounts := make(metrics.MetricEntry)
+func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]int64, mdb MonitoredDatabase) []metrics.MeasurementMessage {
+	allSeverityCounts := make(metrics.Measurement)
 	for _, s := range PgSeverities {
 		parsedCount, ok := eventCounts[s]
 		if ok {
@@ -101,11 +101,11 @@ func eventCountsToMetricStoreMessages(eventCounts, eventCountsTotal map[string]i
 		}
 	}
 	allSeverityCounts["epoch_ns"] = time.Now().UnixNano()
-	return []metrics.MetricStoreMessage{{DBName: mdb.DBUniqueName, DBType: mdb.DBType,
-		MetricName: specialMetricServerLogEventCounts, Data: metrics.MetricData{allSeverityCounts}, CustomTags: mdb.CustomTags}}
+	return []metrics.MeasurementMessage{{DBName: mdb.DBUniqueName, DBType: mdb.DBType,
+		MetricName: specialMetricServerLogEventCounts, Data: metrics.Measurements{allSeverityCounts}, CustomTags: mdb.CustomTags}}
 }
 
-func logparseLoop(dbUniqueName, metricName string, configMap map[string]float64, controlCh <-chan ControlMessage, storeCh chan<- []metrics.MetricStoreMessage) {
+func logparseLoop(dbUniqueName, metricName string, configMap map[string]float64, controlCh <-chan ControlMessage, storeCh chan<- []metrics.MeasurementMessage) {
 
 	var latest, previous, realDbname, serverMessagesLang string
 	var latestHandle *os.File

--- a/src/metrics/io.go
+++ b/src/metrics/io.go
@@ -239,7 +239,7 @@ func ParseMetricAttrsFromYAML(path string) (a MetricAttrs, err error) {
 // Expects "preset metrics" definition file named preset-config.yaml to be present in provided --metrics folder
 func ReadPresetMetricsConfigFromFolder(folder string) (pmm map[string]map[string]float64, err error) {
 	var (
-		pcs           []PresetConfig
+		pcs           []Preset
 		presetMetrics []byte
 	)
 	if presetMetrics, err = os.ReadFile(path.Join(folder, PresetConfigYAMLFile)); err != nil {

--- a/src/metrics/types.go
+++ b/src/metrics/types.go
@@ -1,9 +1,5 @@
 package metrics
 
-import (
-	"time"
-)
-
 type MetricPrometheusAttrs struct {
 	PrometheusGaugeColumns    []string `yaml:"prometheus_gauge_columns"`
 	PrometheusIgnoredColumns  []string `yaml:"prometheus_ignored_columns"` // for cases where we don't want some columns to be exposed in Prom mode
@@ -42,29 +38,21 @@ type MetricProperties struct {
 
 type MetricVersionDefs map[string]map[uint]MetricProperties
 
-type MetricEntry map[string]any
-type MetricData []map[string]any
+type Measurement map[string]any
+type Measurements []map[string]any
 
-type MetricStoreMessage struct {
-	DBName                  string
-	DBType                  string
-	MetricName              string
-	CustomTags              map[string]string
-	Data                    MetricData
-	MetricDefinitionDetails MetricProperties
-	RealDbname              string
-	SystemIdentifier        string
+type MeasurementMessage struct {
+	DBName           string
+	DBType           string
+	MetricName       string
+	CustomTags       map[string]string
+	Data             Measurements
+	MetricDef        MetricProperties
+	RealDbname       string
+	SystemIdentifier string
 }
 
-type MetricStoreMessagePostgres struct {
-	Time    time.Time
-	DBName  string
-	Metric  string
-	Data    map[string]any
-	TagData map[string]any
-}
-
-type PresetConfig struct {
+type Preset struct {
 	Name        string
 	Description string
 	Metrics     map[string]float64

--- a/src/sinks/json_file.go
+++ b/src/sinks/json_file.go
@@ -29,7 +29,7 @@ func NewJSONWriter(ctx context.Context, fname string) (*JSONWriter, error) {
 	}, nil
 }
 
-func (jw *JSONWriter) Write(msgs []metrics.MetricStoreMessage) error {
+func (jw *JSONWriter) Write(msgs []metrics.MeasurementMessage) error {
 	if len(msgs) == 0 {
 		return nil
 	}

--- a/src/sinks/multiwriter.go
+++ b/src/sinks/multiwriter.go
@@ -13,7 +13,7 @@ import (
 // Writer is an interface that writes metrics values
 type Writer interface {
 	SyncMetric(dbUnique, metricName, op string) error
-	Write(msgs []metrics.MetricStoreMessage) error
+	Write(msgs []metrics.MeasurementMessage) error
 }
 
 // MultiWriter ensures the simultaneous storage of data in several storages.
@@ -71,7 +71,7 @@ func (mw *MultiWriter) SyncMetrics(dbUnique, metricName, op string) (err error) 
 	return
 }
 
-func (mw *MultiWriter) WriteMetrics(ctx context.Context, storageCh <-chan []metrics.MetricStoreMessage) {
+func (mw *MultiWriter) WriteMetrics(ctx context.Context, storageCh <-chan []metrics.MeasurementMessage) {
 	var err error
 	logger := log.GetLogger(ctx)
 	for {


### PR DESCRIPTION
Everywhere in code where we are talking about defining what and how to monitor, we call it `Metric`. Everywhere in code where we are working with the real data obtained from sources, we call that `Measurement`.

For example, `"table_bloat"` is a **metric** showing how many bloated space a table occupies. And `"bloat_percent":2,"table_name":"foo", "epoch_ns":1705078795154269000,"real_dbname":"pgwatch3"` is a **measurement**.