### PR TITLE
[+] bump Node to v21, Postgres to v16, Grafana to v10.3 in docker images

### DIFF
--- a/build-docker-demo.sh
+++ b/build-docker-demo.sh
@@ -2,6 +2,6 @@
 docker build \
  --build-arg GIT_TIME=`git show -s --format=%cI HEAD` \
  --build-arg GIT_HASH=`git show -s --format=%H HEAD` \
- --build-arg VERSION=`git rev-parse --abbrev-ref HEAD` \ 
+ --build-arg VERSION=`git rev-parse --abbrev-ref HEAD` \
  -t cybertec/pgwatch3-demo:latest \
  -f docker/demo/Dockerfile .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   postgres:
     # if you want vanilla experience use "postgres:latest" image and remove "timescaledb" from shared_preload_libraries
-    image: &pgimage timescale/timescaledb:latest-pg15
+    image: &pgimage timescale/timescaledb:latest-pg16
     user: postgres
     command:
       - "-cshared_preload_libraries=pg_stat_statements,timescaledb"
@@ -54,7 +54,7 @@ services:
     image: cybertecpostgresql/pgwatch3:latest
     environment:
       PW3_CONFIG: postgresql://pgwatch3@postgres:5432/pgwatch3
-      PW3_PG_METRIC_STORE_CONN_STR: postgresql://pgwatch3@postgres:5432/pgwatch3_metrics
+      PW3_SINK: postgresql://pgwatch3@postgres:5432/pgwatch3_metrics
     ports:
       - "8080:8080"
     depends_on:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------
 # 1. Build Web UI
 # ----------------------------------------------------------------
-FROM node:19 AS uibuilder
+FROM node:21 AS uibuilder
 ADD src/webui /webui
 RUN cd webui && yarn install --network-timeout 100000 && yarn build
 

--- a/docker/bootstrap/init_test_monitored_db.sh
+++ b/docker/bootstrap/init_test_monitored_db.sh
@@ -2,10 +2,8 @@
 
 if [ -n "$PW3_TESTDB" ] ; then
   psql -v ON_ERROR_STOP=1 --username "pgwatch3" --dbname "pgwatch3" <<-EOSQL
-      INSERT INTO pgwatch3.monitored_db (md_unique_name, md_preset_config_name, md_config, md_hostname, md_port, md_dbname, md_user, md_password)
-      SELECT 'test', 'exhaustive', null, 'localhost', '5432', 'pgwatch3', 'pgwatch3', 'pgwatch3admin'
-      WHERE NOT EXISTS (
-          SELECT * FROM pgwatch3.monitored_db WHERE (md_unique_name, md_hostname, md_dbname) = ('test', 'localhost', 'pgwatch3')
-      );
+      INSERT INTO pgwatch3.monitored_db (md_name, md_preset_config_name, md_config, md_connstr)
+      SELECT 'test', 'exhaustive', null, 'postgresql://pgwatch3:pgwatch3admin@localhost:5432/pgwatch3'
+      WHERE NOT EXISTS (SELECT * FROM pgwatch3.monitored_db WHERE md_name = 'test');
 EOSQL
 fi

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------
 # 1. Build Web UI
 # ----------------------------------------------------------------
-FROM node:19 AS uibuilder
+FROM node:21 AS uibuilder
 ADD src/webui /webui
 RUN cd webui && yarn install --network-timeout 100000 && yarn build
 
@@ -21,7 +21,7 @@ RUN cd /pgwatch3 && CGO_ENABLED=0 go build -ldflags "-X 'main.commit=${GIT_HASH}
 # ----------------------------------------------------------------
 # 3. Build the final image
 # ----------------------------------------------------------------
-FROM postgres:15-bullseye AS releaser
+FROM postgres:16-bullseye AS releaser
 
 # Copy over the compiled gatherer
 COPY --from=builder /pgwatch3/pgwatch3 /pgwatch3/
@@ -30,21 +30,21 @@ COPY src/metrics/sql /pgwatch3/metrics
 # Install dependencies
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get -qy install curl gnupg postgresql-common apt-transport-https lsb-release \
+    && apt-get -qy install curl gnupg postgresql-common apt-transport-https lsb-release musl \
     && sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
     && echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(lsb_release -c -s) main" | tee /etc/apt/sources.list.d/timescaledb.list \
     && curl -L "https://packagecloud.io/timescale/timescaledb/gpgkey" | apt-key add - \
     && curl -L "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | apt-key add - \
     && apt-get update \
     && apt-get -qy install \
-        timescaledb-2-postgresql-15 postgresql-plpython3-15 postgresql-15-pg-qualstats \
+        timescaledb-2-postgresql-16 postgresql-plpython3-16 postgresql-16-pg-qualstats \
         supervisor python3-psutil libfontconfig1 \
     && apt-get purge -y --auto-remove \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Grafana
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-    && curl "https://dl.grafana.com/oss/release/grafana_10.0.1_${arch}.deb" --output grafana.deb \
+    && curl "https://dl.grafana.com/oss/release/grafana_10.3.3_${arch}.deb" --output grafana.deb \
     && dpkg -i grafana.deb && rm grafana.deb
 COPY docker/demo/grafana.ini /etc/grafana/grafana.ini
 COPY grafana/postgres_datasource.yml /etc/grafana/provisioning/datasources/pg_ds.yml
@@ -69,16 +69,13 @@ COPY docker/bootstrap/create_role_db.sql \
 RUN  echo "include = 'pgwatch_postgresql.conf'" >> /etc/postgresql/postgresql.conf
 COPY docker/demo/postgresql.conf /etc/postgresql/pgwatch_postgresql.conf
 
-ENV PW3_DATASTORE postgres
-ENV PW3_PG_METRIC_STORE_CONN_STR postgresql://pgwatch3:pgwatch3admin@localhost:5432/pgwatch3_metrics
-ENV PW3_PG_SCHEMA_TYPE timescale
+ENV PW3_CONFIG postgresql://pgwatch3:pgwatch3admin@localhost:5432/pgwatch3
+ENV PW3_SINK postgresql://pgwatch3:pgwatch3admin@localhost:5432/pgwatch3_metrics
 ENV PW3_AES_GCM_KEYPHRASE_FILE /pgwatch3/persistent-config/default-password-encryption-key.txt
 ENV POSTGRES_PASSWORD=mysecretpassword
 
 # Admin UI for configuring servers to be monitored
 EXPOSE 8080
-# Gatherer healthcheck port / metric statistics (JSON)
-EXPOSE 8081
 # Postgres DB holding the pgwatch3 config DB / metrics
 EXPOSE 5432
 # Grafana UI


### PR DESCRIPTION
* bump versions
* use new ENVs, e.g. `PW3_SINK`
* fix docker bootstrap script