### PR TITLE
[*] remove references to deprecated metric files from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,13 +70,8 @@ services:
       PGDATABASE: pgwatch3
     command: >
       psql -v ON_ERROR_STOP=1
-        -f /tmp/00_helpers/get_stat_statements/9.4/metric.sql
-        -f /tmp/00_helpers/get_stat_activity/9.2/metric.sql
-        -f /tmp/00_helpers/get_stat_replication/9.2/metric.sql
         -f /tmp/00_helpers/get_table_bloat_approx/9.5/metric.sql
         -f /tmp/00_helpers/get_table_bloat_approx_sql/12/metric.sql
-        -f /tmp/00_helpers/get_wal_size/10/metric.sql
-        -f /tmp/00_helpers/get_sequences/10/metric.sql 
         -c "INSERT INTO pgwatch3.monitored_db (md_name, md_preset_config_name, md_connstr)
           SELECT 'test', 'exhaustive', 'postgresql://pgwatch3:pgwatch3admin@postgres/pgwatch3'
           WHERE NOT EXISTS (SELECT * FROM pgwatch3.monitored_db WHERE md_name = 'test')"

--- a/docker/bootstrap/2_init_pgwatch_db.sh
+++ b/docker/bootstrap/2_init_pgwatch_db.sh
@@ -7,12 +7,8 @@ EOSQL
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "pgwatch3" \
     -f /pgwatch3/metrics/00_helpers/get_load_average/9.1/metric.sql \
-    -f /pgwatch3/metrics/00_helpers/get_stat_statements/9.4/metric.sql \
-    -f /pgwatch3/metrics/00_helpers/get_stat_activity/9.2/metric.sql \
-    -f /pgwatch3/metrics/00_helpers/get_stat_replication/9.2/metric.sql \
     -f /pgwatch3/metrics/00_helpers/get_table_bloat_approx/9.5/metric.sql \
     -f /pgwatch3/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql \
-    -f /pgwatch3/metrics/00_helpers/get_wal_size/10/metric.sql \
     -f /pgwatch3/metrics/00_helpers/get_psutil_cpu/9.1/metric.sql \
     -f /pgwatch3/metrics/00_helpers/get_psutil_mem/9.1/metric.sql \
     -f /pgwatch3/metrics/00_helpers/get_psutil_disk/9.1/metric.sql \


### PR DESCRIPTION
In PR #371, deprecated helper files were removed, but their references were not removed from the docker-compose.yml file.