### PR TITLE
[+] add test cases to webserver api

### DIFF
--- a/src/webserver/server_test.go
+++ b/src/webserver/server_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const host = "http://localhost:8080"
-
 type Credentials struct {
 	User     string `json:"user"`
 	Password string `json:"password"`
@@ -35,7 +33,8 @@ func TestStatus(t *testing.T) {
 }
 
 func TestServerNoAuth(t *testing.T) {
-	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "localhost:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
+	host := "http://localhost:8081"
+	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "localhost:8081"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
 	assert.NotNil(t, restsrv)
 	rr := httptest.NewRecorder()
 	// test request metrics
@@ -71,7 +70,8 @@ func TestServerNoAuth(t *testing.T) {
 }
 
 func TestGetToken(t *testing.T) {
-	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "localhost:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
+	host := "http://localhost:8082"
+	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "localhost:8082"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
 	rr := httptest.NewRecorder()
 
 	credentials := Credentials{

--- a/src/webserver/server_test.go
+++ b/src/webserver/server_test.go
@@ -1,7 +1,13 @@
 package webserver_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cybertec-postgresql/pgwatch3/config"
@@ -10,14 +16,84 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const host = "http://localhost:8080"
+
+type Credentials struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
 func TestStatus(t *testing.T) {
 	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "127.0.0.1:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
 	assert.NotNil(t, restsrv)
-
 	// r, err := http.Get("http://localhost:8080/")
 	// assert.NoError(t, err)
 	// assert.Equal(t, http.StatusOK, r.StatusCode)
 	// b, err := io.ReadAll(r.Body)
 	// assert.NoError(t, err)
 	// assert.True(t, len(b) > 0)
+}
+
+func TestServerNoAuth(t *testing.T) {
+	restsrv := webserver.Init(config.WebUIOpts{WebAddr: host}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
+	assert.NotNil(t, restsrv)
+	rr := httptest.NewRecorder()
+	// test request metrics
+	req_metric, err := http.NewRequest("GET", host+"/metric", nil)
+	restsrv.Handler.ServeHTTP(rr, req_metric)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
+
+	// test request database
+	req_db, err := http.NewRequest("GET", host+"/db", nil)
+	assert.Equal(t, err, nil)
+	restsrv.Handler.ServeHTTP(rr, req_db)
+	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
+
+	// test request stats
+	req_stats, err := http.NewRequest("GET", host+"/stats", nil)
+	assert.Equal(t, err, nil)
+	restsrv.Handler.ServeHTTP(rr, req_stats)
+	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
+
+	// test request
+	req_log, err := http.NewRequest("GET", host+"/log", nil)
+	assert.Equal(t, err, nil)
+	restsrv.Handler.ServeHTTP(rr, req_log)
+	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
+
+	// request metrics
+	req_connect, err := http.NewRequest("GET", host+"/test-connect", nil)
+	assert.Equal(t, err, nil)
+	restsrv.Handler.ServeHTTP(rr, req_connect)
+	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
+
+}
+
+func TestGetToken(t *testing.T) {
+	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "127.0.0.1:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
+	rr := httptest.NewRecorder()
+
+	credentials := Credentials{
+		User:     "admin",
+		Password: "admin",
+	}
+
+	payload, err := json.Marshal(credentials)
+	if err != nil {
+		fmt.Println("Error marshaling ", err)
+	}
+
+	req_token, err := http.NewRequest("POST", host+"/login", strings.NewReader(string(payload)))
+	assert.Equal(t, err, nil)
+
+	restsrv.Handler.ServeHTTP(rr, req_token)
+
+	assert.Equal(t, rr.Code, http.StatusOK, "TOKEN RESPONSE OK")
+
+	token, err := io.ReadAll(rr.Body)
+	fmt.Println(string(token))
+	assert.Equal(t, err, nil)
+	assert.NotEqual(t, token, nil)
+
 }

--- a/src/webserver/server_test.go
+++ b/src/webserver/server_test.go
@@ -35,7 +35,7 @@ func TestStatus(t *testing.T) {
 }
 
 func TestServerNoAuth(t *testing.T) {
-	restsrv := webserver.Init(config.WebUIOpts{WebAddr: host}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
+	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "localhost:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
 	assert.NotNil(t, restsrv)
 	rr := httptest.NewRecorder()
 	// test request metrics
@@ -71,7 +71,7 @@ func TestServerNoAuth(t *testing.T) {
 }
 
 func TestGetToken(t *testing.T) {
-	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "127.0.0.1:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
+	restsrv := webserver.Init(config.WebUIOpts{WebAddr: "localhost:8080"}, os.DirFS("../webui/build"), nil, log.FallbackLogger)
 	rr := httptest.NewRecorder()
 
 	credentials := Credentials{

--- a/src/webserver/server_test.go
+++ b/src/webserver/server_test.go
@@ -38,33 +38,33 @@ func TestServerNoAuth(t *testing.T) {
 	assert.NotNil(t, restsrv)
 	rr := httptest.NewRecorder()
 	// test request metrics
-	req_metric, err := http.NewRequest("GET", host+"/metric", nil)
-	restsrv.Handler.ServeHTTP(rr, req_metric)
+	reqMetric, err := http.NewRequest("GET", host+"/metric", nil)
+	restsrv.Handler.ServeHTTP(rr, reqMetric)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
 
 	// test request database
-	req_db, err := http.NewRequest("GET", host+"/db", nil)
+	reqDb, err := http.NewRequest("GET", host+"/db", nil)
 	assert.Equal(t, err, nil)
-	restsrv.Handler.ServeHTTP(rr, req_db)
+	restsrv.Handler.ServeHTTP(rr, reqDb)
 	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
 
 	// test request stats
-	req_stats, err := http.NewRequest("GET", host+"/stats", nil)
+	reqStats, err := http.NewRequest("GET", host+"/stats", nil)
 	assert.Equal(t, err, nil)
-	restsrv.Handler.ServeHTTP(rr, req_stats)
+	restsrv.Handler.ServeHTTP(rr, reqStats)
 	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
 
 	// test request
-	req_log, err := http.NewRequest("GET", host+"/log", nil)
+	reqLog, err := http.NewRequest("GET", host+"/log", nil)
 	assert.Equal(t, err, nil)
-	restsrv.Handler.ServeHTTP(rr, req_log)
+	restsrv.Handler.ServeHTTP(rr, reqLog)
 	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
 
 	// request metrics
-	req_connect, err := http.NewRequest("GET", host+"/test-connect", nil)
+	reqConnect, err := http.NewRequest("GET", host+"/test-connect", nil)
 	assert.Equal(t, err, nil)
-	restsrv.Handler.ServeHTTP(rr, req_connect)
+	restsrv.Handler.ServeHTTP(rr, reqConnect)
 	assert.Equal(t, rr.Code, http.StatusUnauthorized, "REQUEST WITHOUT AUTHENTICATION")
 
 }
@@ -84,10 +84,10 @@ func TestGetToken(t *testing.T) {
 		fmt.Println("Error marshaling ", err)
 	}
 
-	req_token, err := http.NewRequest("POST", host+"/login", strings.NewReader(string(payload)))
+	reqToken, err := http.NewRequest("POST", host+"/login", strings.NewReader(string(payload)))
 	assert.Equal(t, err, nil)
 
-	restsrv.Handler.ServeHTTP(rr, req_token)
+	restsrv.Handler.ServeHTTP(rr, reqToken)
 
 	assert.Equal(t, rr.Code, http.StatusOK, "TOKEN RESPONSE OK")
 


### PR DESCRIPTION
while I was trying to understand how the webserver worked I noticed that the tests had not yet been written, so I wanted to try to write some to better understand how the API works and to help those who come after me to understand how to use the api as the tests also partly act as documentation.

This pull request adds test cases for the webserver module. I've included test cases for the main routes to ensure they return the expected responses. These tests use the httptest package to mock HTTP requests.

Please review and let me know your feedback.

Changes Made:
- Added test cases for the webserver module
- Utilized httptest package to mock HTTP requests
- Ensured that the main routes return the expected responses
- Ensure that the jwt token works

Files Changed:
- src/webserver/server_test.go: Added test cases for the webserver module
