### PR TITLE
[*] update docker compose command to force recreate test database

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ looking at metrics. You may log in as admin (`admin`/`admin`) to apply changes t
 To add a test database under monitoring, you can use [built-in WebUI](http://localhost:8080/). Or simply
 execute from command line:
 ```shell
-$ docker compose up add-test-db
+$ docker compose up add-test-db --force-recreate
 ```
 <pre>
 [+] Running 2/0


### PR DESCRIPTION
> [+] Running 2/0
>  ✔ Container pgwatch3-postgres-1     Running                                         0.0s 
>  ✔ Container pgwatch3-add-test-db-1  Created                                         0.0s 
> Attaching to add-test-db-1
> Error response from daemon: network 5fd3cac23c91c89c3a2ae3743fb9ef5665a1bca5c3ff1b3a6e43b6cbd53fda16 not found
> Gracefully stopping... (press Ctrl+C again to force)

Since the container have been created and exited, it will reattach to the old container and fail. So we need to `force recreate` after `docker compose down` if we want to add test db again