### PR TITLE
[-] if presets are used then skip single metric checks, fixes #401

### DIFF
--- a/src/config/cmdoptions.go
+++ b/src/config/cmdoptions.go
@@ -101,11 +101,6 @@ func New(writer io.Writer) (*Options, error) {
 	return cmdOpts, validateConfig(cmdOpts)
 }
 
-func checkFolderExistsAndReadable(path string) bool {
-	_, err := os.ReadDir(path)
-	return err == nil
-}
-
 // Verbose returns true if the debug log is enabled
 func (c Options) Verbose() bool {
 	return c.Logging.LogLevel == "debug"

--- a/src/main.go
+++ b/src/main.go
@@ -1190,7 +1190,7 @@ func NewConfigurationReaders(opts *config.Options) (sources.Reader, metrics.Read
 		ctx := log.WithLogger(mainContext, logger.WithField("config", "folder"))
 		sourcesReader, err = sources.NewYAMLSourcesReader(ctx, opts)
 		checkError(err)
-		metricsReader, err = metrics.NewYAMLMetricReader(ctx, opts)
+		metricsReader, err = metrics.NewYAMLMetricReader(ctx, opts.Sources.Config)
 	case configKind == config.ConfigPgURL:
 		ctx := log.WithLogger(mainContext, logger.WithField("config", "postgres"))
 		configDb, err = db.New(ctx, opts.Sources.Config)

--- a/src/main.go
+++ b/src/main.go
@@ -1325,38 +1325,38 @@ func main() {
 
 		firstLoop = false // only used for failing when 1st config reading fails
 
-		for _, source := range monitoredDbs {
-			logger.WithField("source", source.DBUniqueName).
-				WithField("metric", source.Metrics).
-				WithField("tags", source.CustomTags).
-				WithField("config", source.HostConfig).Debug()
+		for _, monitoredDB := range monitoredDbs {
+			logger.WithField("source", monitoredDB.DBUniqueName).
+				WithField("metric", monitoredDB.Metrics).
+				WithField("tags", monitoredDB.CustomTags).
+				WithField("config", monitoredDB.HostConfig).Debug()
 
-			dbUnique := source.DBUniqueName
-			dbUniqueOrig := source.DBUniqueNameOrig
-			srcType := source.Kind
+			dbUnique := monitoredDB.DBUniqueName
+			dbUniqueOrig := monitoredDB.DBUniqueNameOrig
+			srcType := monitoredDB.Kind
 			metricConfig = func() map[string]float64 {
-				if len(source.Metrics) > 0 {
-					return source.Metrics
+				if len(monitoredDB.Metrics) > 0 {
+					return monitoredDB.Metrics
 				}
-				if source.PresetMetrics > "" {
-					return metricDefinitionMap.PresetDefs[source.PresetMetrics].Metrics
+				if monitoredDB.PresetMetrics > "" {
+					return metricDefinitionMap.PresetDefs[monitoredDB.PresetMetrics].Metrics
 				}
 				return nil
 			}()
 			wasInstancePreviouslyDormant := IsDBDormant(dbUnique)
 
-			if source.Encryption == "aes-gcm-256" && len(opts.Sources.AesGcmKeyphrase) == 0 && len(opts.Sources.AesGcmKeyphraseFile) == 0 {
+			if monitoredDB.Encryption == "aes-gcm-256" && len(opts.Sources.AesGcmKeyphrase) == 0 && len(opts.Sources.AesGcmKeyphraseFile) == 0 {
 				// Warn if any encrypted hosts found but no keyphrase given
 				logger.Warningf("Encrypted password type found for host \"%s\", but no decryption keyphrase specified. Use --aes-gcm-keyphrase or --aes-gcm-keyphrase-file params", dbUnique)
 			}
 
-			err := InitSQLConnPoolForMonitoredDBIfNil(source)
+			err := InitSQLConnPoolForMonitoredDBIfNil(monitoredDB)
 			if err != nil {
 				logger.Warningf("Could not init SQL connection pool for %s, retrying on next main loop. Err: %v", dbUnique, err)
 				continue
 			}
 
-			InitPGVersionInfoFetchingLockIfNil(source)
+			InitPGVersionInfoFetchingLockIfNil(monitoredDB)
 
 			_, connectFailedSoFar := failedInitialConnectHosts[dbUnique]
 
@@ -1380,33 +1380,33 @@ func main() {
 				if connectFailedSoFar {
 					delete(failedInitialConnectHosts, dbUnique)
 				}
-				if ver.IsInRecovery && source.OnlyIfMaster {
+				if ver.IsInRecovery && monitoredDB.OnlyIfMaster {
 					logger.Infof("[%s] not added to monitoring due to 'master only' property", dbUnique)
 					continue
 				}
 				metricConfig = func() map[string]float64 {
-					if len(source.Metrics) > 0 {
-						return source.Metrics
+					if len(monitoredDB.Metrics) > 0 {
+						return monitoredDB.Metrics
 					}
-					if source.PresetMetrics > "" {
-						return metricDefinitionMap.PresetDefs[source.PresetMetrics].Metrics
+					if monitoredDB.PresetMetrics > "" {
+						return metricDefinitionMap.PresetDefs[monitoredDB.PresetMetrics].Metrics
 					}
 					return nil
 				}()
 				hostLastKnownStatusInRecovery[dbUnique] = ver.IsInRecovery
 				if ver.IsInRecovery {
 					metricConfig = func() map[string]float64 {
-						if len(source.MetricsStandby) > 0 {
-							return source.MetricsStandby
+						if len(monitoredDB.MetricsStandby) > 0 {
+							return monitoredDB.MetricsStandby
 						}
-						if source.PresetMetricsStandby > "" {
-							return metricDefinitionMap.PresetDefs[source.PresetMetricsStandby].Metrics
+						if monitoredDB.PresetMetricsStandby > "" {
+							return metricDefinitionMap.PresetDefs[monitoredDB.PresetMetricsStandby].Metrics
 						}
 						return nil
 					}()
 				}
 
-				if !opts.Ping && source.IsPostgresSource() && !ver.IsInRecovery {
+				if !opts.Ping && monitoredDB.IsPostgresSource() && !ver.IsInRecovery {
 					if opts.Metrics.NoHelperFunctions {
 						logger.Infof("[%s] skipping rollout out helper functions due to the --no-helper-functions flag ...", dbUnique)
 					} else {
@@ -1419,7 +1419,7 @@ func main() {
 
 			}
 
-			if source.IsPostgresSource() {
+			if monitoredDB.IsPostgresSource() {
 				var DBSizeMB int64
 
 				if opts.Sources.MinDbSizeMB >= 8 { // an empty DB is a bit less than 8MB
@@ -1434,22 +1434,22 @@ func main() {
 						SetUndersizedDBState(dbUnique, false)
 					}
 				}
-				ver, err := DBGetPGVersion(mainContext, dbUnique, source.Kind, false)
+				ver, err := DBGetPGVersion(mainContext, dbUnique, monitoredDB.Kind, false)
 				if err == nil { // ok to ignore error, re-tried on next loop
 					lastKnownStatusInRecovery := hostLastKnownStatusInRecovery[dbUnique]
-					if ver.IsInRecovery && source.OnlyIfMaster {
+					if ver.IsInRecovery && monitoredDB.OnlyIfMaster {
 						logger.Infof("[%s] to be removed from monitoring due to 'master only' property and status change", dbUnique)
 						hostsToShutDownDueToRoleChange[dbUnique] = true
 						SetRecoveryIgnoredDBState(dbUnique, true)
 						continue
 					} else if lastKnownStatusInRecovery != ver.IsInRecovery {
-						if ver.IsInRecovery && len(source.MetricsStandby) > 0 {
+						if ver.IsInRecovery && len(monitoredDB.MetricsStandby) > 0 {
 							logger.Warningf("Switching metrics collection for \"%s\" to standby config...", dbUnique)
-							metricConfig = source.MetricsStandby
+							metricConfig = monitoredDB.MetricsStandby
 							hostLastKnownStatusInRecovery[dbUnique] = true
 						} else {
 							logger.Warningf("Switching metrics collection for \"%s\" to primary config...", dbUnique)
-							metricConfig = source.Metrics
+							metricConfig = monitoredDB.Metrics
 							hostLastKnownStatusInRecovery[dbUnique] = false
 							SetRecoveryIgnoredDBState(dbUnique, false)
 						}
@@ -1520,7 +1520,7 @@ func main() {
 					}
 				} else if (!metricDefOk && chOk) || interval <= 0 {
 					// metric definition files were recently removed or interval set to zero
-					logger.Warning("shutting down metric", metric, "for", source.DBUniqueName)
+					logger.Warning("shutting down metric", metric, "for", monitoredDB.DBUniqueName)
 					controlChannels[dbMetric] <- metrics.ControlMessage{Action: gathererStatusStop}
 					delete(controlChannels, dbMetric)
 				} else if !metricDefOk {
@@ -1587,7 +1587,9 @@ func main() {
 					logger.Warningf("Could not find PG version info for DB %s, skipping shutdown check of metric worker process for %s", db, metric)
 					continue
 				}
-
+				if verInfo.IsInRecovery && dbInfo.PresetMetricsStandby > "" || !verInfo.IsInRecovery && dbInfo.PresetMetrics > "" {
+					continue // no need to check presets for single metric disabling
+				}
 				if verInfo.IsInRecovery && len(dbInfo.MetricsStandby) > 0 {
 					currentMetricConfig = dbInfo.MetricsStandby
 				} else {

--- a/src/main.go
+++ b/src/main.go
@@ -119,8 +119,6 @@ var monitoredDbCacheLock sync.RWMutex
 var monitoredDbConnCacheLock = sync.RWMutex{}
 var lastSQLFetchError sync.Map
 
-var fileBasedMetrics = false
-
 // / internal statistics calculation
 var lastSuccessfulDatastoreWriteTimeEpoch int64
 var datastoreWriteFailuresCounter uint64

--- a/src/metrics/postgres.go
+++ b/src/metrics/postgres.go
@@ -15,7 +15,7 @@ func NewPostgresMetricReader(ctx context.Context, conn db.PgxPoolIface, opts *co
 			if err != nil {
 				return nil, err
 			}
-			defer tx.Rollback(ctx)
+			defer func() { _ = tx.Rollback(ctx) }()
 			if _, err := tx.Exec(ctx, db.SQLConfigSchema); err != nil {
 				return nil, err
 			}
@@ -52,7 +52,7 @@ func WriteMetricsToPostgres(ctx context.Context, conn db.PgxIface, metricDefs *M
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 	for metricName, metric := range metricDefs.MetricDefs {
 		_, err = tx.Exec(ctx, `INSERT INTO pgwatch3.metric (name, sqls, description, enabled, node_status, gauges, is_instance_level, storage_name)
 		values ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (name, node_status) 

--- a/src/metrics/yaml.go
+++ b/src/metrics/yaml.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"os"
 
-	"github.com/cybertec-postgresql/pgwatch3/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,10 +21,10 @@ func GetDefaultMetrics() (metrics *Metrics) {
 	return
 }
 
-func NewYAMLMetricReader(ctx context.Context, opts *config.Options) (Reader, error) {
+func NewYAMLMetricReader(ctx context.Context, path string) (Reader, error) {
 	return &fileMetricReader{
 		ctx:  ctx,
-		path: opts.Sources.Config,
+		path: path,
 	}, nil
 }
 

--- a/src/metrics/yaml_test.go
+++ b/src/metrics/yaml_test.go
@@ -1,7 +1,6 @@
 package metrics_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -45,10 +44,11 @@ func TestWriteMetricsToFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Read the contents of the file
-	data, err := ioutil.ReadFile(tempFile)
+	fmr, err := metrics.NewYAMLMetricReader(nil, tempFile)
+	assert.NoError(t, err)
+	metrics, err := fmr.GetMetrics()
 	assert.NoError(t, err)
 
 	// Assert that the file contains the expected data
-	expectedData := []byte(`` /* Put your expected YAML data here */)
-	assert.Equal(t, expectedData, data)
+	assert.Equal(t, metricDefs, *metrics)
 }

--- a/src/metrics/yaml_test.go
+++ b/src/metrics/yaml_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestWriteMetricsToFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Read the contents of the file
-	fmr, err := metrics.NewYAMLMetricReader(nil, tempFile)
+	fmr, err := metrics.NewYAMLMetricReader(context.Background(), tempFile)
 	assert.NoError(t, err)
 	metrics, err := fmr.GetMetrics()
 	assert.NoError(t, err)

--- a/src/sources/postgres.go
+++ b/src/sources/postgres.go
@@ -25,12 +25,14 @@ type dbSourcesReader struct {
 
 func (r *dbSourcesReader) GetMonitoredDatabases() (dbs MonitoredDatabases, err error) {
 	sqlLatest := `select /* pgwatch3_generated */
-	s.name, 
+	name, 
 	"group", 
 	dbtype, 
 	connstr,
-	coalesce(pr.metrics, config) as config, 
-	coalesce(st.metrics, config_standby, '{}'::jsonb) as config_standby,
+	coalesce(config, '{}'::jsonb) as config, 
+	coalesce(config_standby, '{}'::jsonb) as config_standby,
+	coalesce(preset_config, '') as preset_config,
+	coalesce(preset_config_standby, '') as preset_config_standby,
 	is_superuser,
 	coalesce(include_pattern, '') as include_pattern, 
 	coalesce(exclude_pattern, '') as exclude_pattern,
@@ -38,9 +40,7 @@ func (r *dbSourcesReader) GetMonitoredDatabases() (dbs MonitoredDatabases, err e
 	encryption, coalesce(host_config, '{}') as host_config, 
 	only_if_master
 from
-	pgwatch3.source s
-	left join pgwatch3.preset pr on pr.name = preset_config
-	left join pgwatch3.preset st on st.name = preset_config_standby
+	pgwatch3.source
 `
 	rows, err := r.configDb.Query(context.Background(), sqlLatest)
 	if err != nil {


### PR DESCRIPTION
[*] make sources postgres reader follow the same pattern as YAML reader