### PR TITLE
[+] add pgAdmin4 to `docker-compose.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ pgwatch3-pgbench-1 exited with code 0
 
 ## Inspect database
 
-**Warning:** pgadmin uses port 80. If you want it to use another port, change it in `docker-compose.yml` file.
+> [!IMPORTANT]
+pgAdmin uses port 80. If you want it to use another port, change it in `docker-compose.yml` file.
 
 To look what is inside postgres database, you can spin up pgadmin:
 ```shell

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ To look what is inside `pgwatch3` database, you can spin up pgAdmin4:
 ```shell
 docker compose up --detach pgadmin
 ```
-Go to localhost in your favorite browser and login as `admin@local.com`, password `admin`. Then add new server with 
-name `pgwatch3`, in tab connection enter host name `postgres`, user `pgwatch3`, password `pgwatch3admin`.
+Go to `localhost` in your favorite browser and login as `admin@local.com`, password `admin`.
+Server `pgwatch3` should be already added in `Servers` group.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ pgwatch3-pgbench-1 exited with code 0
 > [!IMPORTANT]
 pgAdmin uses port 80. If you want it to use another port, change it in `docker-compose.yml` file.
 
-To look what is inside postgres database, you can spin up pgadmin:
+To look what is inside `pgwatch3` database, you can spin up pgAdmin4:
 ```shell
 docker compose up --detach pgadmin
 ```

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ These commands will build and start services listed in the compose file:
 ## Monitor Database
 
 After start, you could open the [monitoring dashboard](http://localhost:3000/) and start
-looking at metrics. You may log in as admin (`admin`/`admin`) to apply changes to dashboards or create new ones.
+looking at metrics.
 
 To add a test database under monitoring, you can use [built-in WebUI](http://localhost:8080/). Or simply
 execute from command line:
 ```shell
-$ docker compose up add-test-db --force-recreate
+docker compose up add-test-db --force-recreate
 ```
 <pre>
 [+] Running 2/0
@@ -57,8 +57,8 @@ pgwatch3-add-test-db-1 exited with code 0
 ## Produce Workload
 
 To emulate workload for added test database execute:
-```
-$ docker compose up pgbench
+```shell
+docker compose up pgbench
 ```
 <pre>
 [+] Running 2/2
@@ -88,7 +88,7 @@ pgwatch3-pgbench-1  | progress: 10.0 s, 509.6 tps, lat 19.541 ms stddev 9.493, 0
 pgwatch3-pgbench-1  | progress: 185.0 s, 325.3 tps, lat 16.825 ms stddev 8.330, 0 failed
 pgwatch3-pgbench-1  |
 pgwatch3-pgbench-1  |
-pgwatch3-pgbench-1  | transaction type: <builtin: TPC-B (sort of)>
+pgwatch3-pgbench-1  | transaction type: builtin: TPC-B (sort of)
 pgwatch3-pgbench-1  | scaling factor: 50
 pgwatch3-pgbench-1  | query mode: simple
 pgwatch3-pgbench-1  | number of clients: 10
@@ -106,12 +106,23 @@ pgwatch3-pgbench-1  | done in 0.45 s (drop tables 0.45 s).
 pgwatch3-pgbench-1 exited with code 0
 </pre>
 
+## Inspect database
+
+**Warning:** pgadmin uses port 80. If you want it to use another port, change it in `docker-compose.yml` file.
+
+To look what is inside postgres database, you can spin up pgadmin:
+```shell
+docker compose up --detach pgadmin
+```
+Go to localhost in your favorite browser and login as `admin@local.com`, password `admin`. Then add new server with 
+name `pgwatch3`, in tab connection enter host name `postgres`, user `pgwatch3`, password `pgwatch3admin`.
+
 ## Development
 
 If you apply any changes to the source code and want to restart the agent, it's usually enough to run:
 
 ```shell
-$ docker compose up pgwatch3 --build --force-recreate --detach
+docker compose up pgwatch3 --build --force-recreate --detach
 ```
 
 The command above will rebuild the `pgwatch3` agent from sources and relaunch the container.
@@ -120,12 +131,12 @@ The command above will rebuild the `pgwatch3` agent from sources and relaunch th
 
 If you are running containers in detached mode, you still can follow the logs:
 ```shell
-$ docker compose logs --follow
+docker compose logs --follow
 ```
 
 Or you may check the log of a particular service:
 ```shell
-$ docker compose logs pgwatch3 --follow
+docker compose logs pgwatch3 --follow
 ```
 
 # Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: true
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/1-global-db-overview.json
       GF_INSTALL_PLUGINS: marcusolsson-treemap-panel
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
     ports:
       - "3000:3000"
     restart: unless-stopped
@@ -100,12 +101,24 @@ services:
     profiles:
       - pgbench
 
-  # prometheus:
-  #   image: prom/prometheus
-  #   command:
-  #     - '--config.file=/etc/prometheus/prometheus.yml'
-  #   ports:
-  #     - 9090:9090
-  #   restart: unless-stopped
-  #   volumes:
-  #     - "./docker/prometheus.yml:/etc/prometheus/prometheus.yml"
+  prometheus:
+    image: prom/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - "./docker/prometheus.yml:/etc/prometheus/prometheus.yml"
+    profiles:
+      - prometheus
+
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@local.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "80:80"
+    profiles:
+      - pgadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,9 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@local.com
       PGADMIN_DEFAULT_PASSWORD: admin
+    volumes:
+      - "./docker/pgadmin_servers.json:/pgadmin4/servers.json"
+      - "./docker/pgadmin_pass:/pgadmin4/pass"
     ports:
       - "80:80"
     profiles:

--- a/docker/pgadmin_pass
+++ b/docker/pgadmin_pass
@@ -1,0 +1,1 @@
+postgres:5432:postgres:pgwatch3:pgwatch3admin

--- a/docker/pgadmin_servers.json
+++ b/docker/pgadmin_servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "pgwatch3",
+      "Group": "Servers",
+      "Port": 5432,
+      "Username": "pgwatch3",
+      "Host": "postgres",
+      "PassFile": "/pgadmin4/pass",
+      "SSLMode": "disable",
+      "MaintenanceDB": "postgres"
+    }
+  }
+}


### PR DESCRIPTION
- Add PGadmin into docker-compose.yml and README.md
- Change default login in Grafana to be admin, so you don't have to log in to change dashboards.
- Uncomments Prometheus section in docker compose file and adds profile so it can be started separately.
- Small changes in README.md like removing < > in pre tag, it was messing with how idea renders MD files.