### PR TITLE
[-] fix `dbMetricReaderWriter.initMigrator()` and init `reaper.metricDefinitioMap`

### DIFF
--- a/src/metrics/postgres_schema.go
+++ b/src/metrics/postgres_schema.go
@@ -15,24 +15,20 @@ func (dmrw *dbMetricReaderWriter) initMigrator() (*migrator.Migrator, error) {
 	if pgxMigrator != nil {
 		return pgxMigrator, nil
 	}
-	m, err := migrator.New(
+	return migrator.New(
 		migrator.TableName("pgwatch3.migration"),
 		migrator.SetNotice(func(s string) {
 			log.GetLogger(dmrw.ctx).Info(s)
 		}),
 		migrations(),
 	)
-    if err != nil{
-        return nil, fmt.Errorf("cannot initialize migration: %w", err)
-    }
-	return m, nil
 }
 
 // MigrateDb upgrades database with all migrations
 func (dmrw *dbMetricReaderWriter) Migrate() error {
 	m, err := dmrw.initMigrator()
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot initialize migration: %w", err)
 	}
 	return m.Migrate(dmrw.ctx, dmrw.configDb)
 }

--- a/src/metrics/postgres_schema.go
+++ b/src/metrics/postgres_schema.go
@@ -22,7 +22,10 @@ func (dmrw *dbMetricReaderWriter) initMigrator() (*migrator.Migrator, error) {
 		}),
 		migrations(),
 	)
-	return m, fmt.Errorf("cannot initialize migration: %w", err)
+    if err != nil{
+        return nil, fmt.Errorf("cannot initialize migration: %w", err)
+    }
+	return m, nil
 }
 
 // MigrateDb upgrades database with all migrations

--- a/src/reaper/reaper.go
+++ b/src/reaper/reaper.go
@@ -21,7 +21,7 @@ import (
 var monitoredDbs sources.MonitoredDatabases
 var hostLastKnownStatusInRecovery = make(map[string]bool) // isInRecovery
 var metricConfig map[string]float64                       // set to host.Metrics or host.MetricsStandby (in case optional config defined and in recovery state
-var metricDefinitionMap *metrics.Metrics
+var metricDefinitionMap *metrics.Metrics = &metrics.Metrics{}
 var metricDefMapLock = sync.RWMutex{}
 
 type Reaper struct {


### PR DESCRIPTION
Earlier we were returning the error along with the migrator. Fixed it to return error only when it occurs