### PR TITLE
[!] differentiate the concepts of source and monitored database

### DIFF
--- a/src/reaper/database.go
+++ b/src/reaper/database.go
@@ -948,7 +948,7 @@ func TryCreateMetricsFetchingHelpers(ctx context.Context, md *sources.MonitoredD
 
 		_, err = c.Exec(ctx, Metric.InitSQL)
 		if err != nil {
-			log.GetLogger(ctx).Warningf("Failed to create a metric fetching helper for %s in %s: %w", md.DBUniqueName, metricName, err)
+			log.GetLogger(ctx).Warningf("Failed to create a metric fetching helper for %s in %s: %v", md.DBUniqueName, metricName, err)
 		} else {
 			log.GetLogger(ctx).Info("Successfully created metric fetching helper for", md.DBUniqueName, metricName)
 		}

--- a/src/sources/postgres.go
+++ b/src/sources/postgres.go
@@ -23,7 +23,7 @@ type dbSourcesReaderWriter struct {
 	configDb db.PgxIface
 }
 
-func (r *dbSourcesReaderWriter) WriteMonitoredDatabases(dbs MonitoredDatabases) error {
+func (r *dbSourcesReaderWriter) WriteSources(dbs Sources) error {
 	tx, err := r.configDb.Begin(context.Background())
 	if err != nil {
 		return err
@@ -40,7 +40,7 @@ func (r *dbSourcesReaderWriter) WriteMonitoredDatabases(dbs MonitoredDatabases) 
 	return tx.Commit(context.Background())
 }
 
-func (r *dbSourcesReaderWriter) updateDatabase(conn db.PgxIface, md *MonitoredDatabase) (err error) {
+func (r *dbSourcesReaderWriter) updateDatabase(conn db.PgxIface, md Source) (err error) {
 	m := db.MarshallParam
 	sql := `insert into pgwatch3.source(
 	name, 
@@ -81,16 +81,16 @@ on conflict (name) do update set
 	return err
 }
 
-func (r *dbSourcesReaderWriter) UpdateDatabase(md *MonitoredDatabase) error {
+func (r *dbSourcesReaderWriter) UpdateSource(md Source) error {
 	return r.updateDatabase(r.configDb, md)
 }
 
-func (r *dbSourcesReaderWriter) DeleteDatabase(name string) error {
+func (r *dbSourcesReaderWriter) DeleteSource(name string) error {
 	_, err := r.configDb.Exec(context.Background(), `delete from pgwatch3.source where name = $1`, name)
 	return err
 }
 
-func (r *dbSourcesReaderWriter) GetMonitoredDatabases() (dbs MonitoredDatabases, err error) {
+func (r *dbSourcesReaderWriter) GetSources() (dbs Sources, err error) {
 	sqlLatest := `select /* pgwatch3_generated */
 	name, 
 	"group", 
@@ -113,6 +113,6 @@ from
 	if err != nil {
 		return nil, err
 	}
-	dbs, err = pgx.CollectRows[*MonitoredDatabase](rows, pgx.RowToAddrOfStructByNameLax)
+	dbs, err = pgx.CollectRows[Source](rows, pgx.RowToStructByNameLax)
 	return
 }

--- a/src/sources/postgres_test.go
+++ b/src/sources/postgres_test.go
@@ -51,6 +51,33 @@ func TestGetMonitoredDatabases(t *testing.T) {
 	a.Nil(dbs)
 	a.NoError(conn.ExpectationsWereMet())
 }
+
+func TestSyncFromReader(t *testing.T) {
+	a := assert.New(t)
+	conn, err := pgxmock.NewPool()
+	a.NoError(err)
+	conn.ExpectPing()
+	conn.ExpectQuery(`select \/\* pgwatch3_generated \*\/`).WillReturnRows(pgxmock.NewRows([]string{
+		"name", "group", "dbtype", "connstr", "config", "config_standby", "preset_config",
+		"preset_config_standby", "is_superuser", "include_pattern", "exclude_pattern",
+		"custom_tags", "host_config", "only_if_master", "is_enabled",
+	}).AddRow(
+		"db1", "group1", sources.Kind("postgres"), "postgres://user:pass@localhost:5432/db1",
+		map[string]float64{"metric": 60}, map[string]float64{"standby_metric": 60}, "exhaustive", "exhaustive",
+		true, ".*", `\_.+`, map[string]string{"tag": "value"}, nil, true, true,
+	))
+	pgrw, err := sources.NewPostgresSourcesReaderWriter(ctx, conn)
+	a.NoError(err)
+
+	md := &sources.MonitoredDatabase{}
+	md.DBUniqueName = "db1"
+	dbs := sources.MonitoredDatabases{md}
+	dbs, err = dbs.SyncFromReader(pgrw)
+	a.NoError(err)
+	a.Len(dbs, 1)
+	a.NoError(conn.ExpectationsWereMet())
+}
+
 func TestDeleteDatabase(t *testing.T) {
 	a := assert.New(t)
 	conn, err := pgxmock.NewPool()

--- a/src/sources/postgres_test.go
+++ b/src/sources/postgres_test.go
@@ -133,7 +133,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 	a := assert.New(t)
 	conn, err := pgxmock.NewPool()
 	a.NoError(err)
-	md := &sources.Source{
+	md := sources.Source{
 		DBUniqueName:   "db1",
 		Group:          "group1",
 		Kind:           sources.Kind("postgres"),

--- a/src/sources/postgres_test.go
+++ b/src/sources/postgres_test.go
@@ -39,14 +39,14 @@ func TestGetMonitoredDatabases(t *testing.T) {
 	pgrw, err := sources.NewPostgresSourcesReaderWriter(ctx, conn)
 	a.NoError(err)
 
-	dbs, err := pgrw.GetMonitoredDatabases()
+	dbs, err := pgrw.GetSources()
 	a.NoError(err)
 	a.Len(dbs, 1)
 	a.NoError(conn.ExpectationsWereMet())
 
 	// check failed query
 	conn.ExpectQuery(`select \/\* pgwatch3_generated \*\/`).WillReturnError(errors.New("failed query"))
-	dbs, err = pgrw.GetMonitoredDatabases()
+	dbs, err = pgrw.GetSources()
 	a.Error(err)
 	a.Nil(dbs)
 	a.NoError(conn.ExpectationsWereMet())
@@ -60,7 +60,7 @@ func TestDeleteDatabase(t *testing.T) {
 	pgrw, err := sources.NewPostgresSourcesReaderWriter(ctx, conn)
 	a.NoError(err)
 
-	err = pgrw.DeleteDatabase("db1")
+	err = pgrw.DeleteSource("db1")
 	a.NoError(err)
 	a.NoError(conn.ExpectationsWereMet())
 }
@@ -70,7 +70,7 @@ func TestUpdateDatabase(t *testing.T) {
 	conn, err := pgxmock.NewPool()
 	a.NoError(err)
 
-	md := &sources.MonitoredDatabase{
+	md := sources.Source{
 		DBUniqueName:   "db1",
 		Group:          "group1",
 		Kind:           sources.Kind("postgres"),
@@ -93,7 +93,7 @@ func TestUpdateDatabase(t *testing.T) {
 
 	pgrw, err := sources.NewPostgresSourcesReaderWriter(ctx, conn)
 	a.NoError(err)
-	err = pgrw.UpdateDatabase(md)
+	err = pgrw.UpdateSource(md)
 	a.NoError(err)
 	a.NoError(conn.ExpectationsWereMet())
 }
@@ -106,7 +106,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 	a := assert.New(t)
 	conn, err := pgxmock.NewPool()
 	a.NoError(err)
-	md := &sources.MonitoredDatabase{
+	md := &sources.Source{
 		DBUniqueName:   "db1",
 		Group:          "group1",
 		Kind:           sources.Kind("postgres"),
@@ -118,7 +118,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 		ExcludePattern: `\_.+`,
 		CustomTags:     map[string]string{"tag": "value"},
 	}
-	mds := sources.MonitoredDatabases{md}
+	mds := sources.Sources{md}
 
 	t.Run("happy path", func(*testing.T) {
 		conn.ExpectPing()
@@ -135,7 +135,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 
 		pgrw, err = sources.NewPostgresSourcesReaderWriter(ctx, conn)
 		a.NoError(err)
-		err = pgrw.WriteMonitoredDatabases(mds)
+		err = pgrw.WriteSources(mds)
 		a.NoError(err)
 		a.NoError(conn.ExpectationsWereMet())
 	})
@@ -143,7 +143,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 	t.Run("failed transaction begin", func(*testing.T) {
 		conn.ExpectBegin().WillReturnError(errors.New("failed transaction begin"))
 
-		err = pgrw.WriteMonitoredDatabases(mds)
+		err = pgrw.WriteSources(mds)
 		a.Error(err)
 		a.NoError(conn.ExpectationsWereMet())
 	})
@@ -152,7 +152,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 		conn.ExpectBegin()
 		conn.ExpectExec(`truncate pgwatch3\.source`).WillReturnError(errors.New("failed truncate"))
 
-		err = pgrw.WriteMonitoredDatabases(mds)
+		err = pgrw.WriteSources(mds)
 		a.Error(err)
 		a.NoError(conn.ExpectationsWereMet())
 	})
@@ -168,7 +168,7 @@ func TestWriteMonitoredDatabases(t *testing.T) {
 		).WillReturnError(errors.New("failed insert"))
 		conn.ExpectRollback()
 
-		err = pgrw.WriteMonitoredDatabases(mds)
+		err = pgrw.WriteSources(mds)
 		a.Error(err)
 		a.NoError(conn.ExpectationsWereMet())
 	})

--- a/src/sources/resolver_test.go
+++ b/src/sources/resolver_test.go
@@ -25,7 +25,9 @@ func TestMonitoredDatabase_ResolveDatabasesFromPostgres(t *testing.T) {
 	defer func() { assert.NoError(t, pgContainer.Terminate(ctx)) }()
 
 	// Create a new MonitoredDatabase instance
-	md := &sources.MonitoredDatabase{DBUniqueName: "continuous", Kind: sources.SourcePostgresContinuous}
+	md := sources.Source{}
+	md.DBUniqueName = "continuous"
+	md.Kind = sources.SourcePostgresContinuous
 	md.ConnStr, err = pgContainer.ConnectionString(ctx)
 	assert.NoError(t, err)
 

--- a/src/sources/types.go
+++ b/src/sources/types.go
@@ -79,14 +79,6 @@ func (s *Source) Clone() *Source {
 	return c
 }
 
-func (srcs Sources) GetMonitoredDatabase() MonitoredDatabases {
-	mds := make(MonitoredDatabases, len(srcs))
-	for i, src := range srcs {
-		mds[i] = &MonitoredDatabase{Source: src}
-	}
-	return mds
-}
-
 // MonitoredDatabase represents a single database to monitor. Unlike source, it contains a database connection.
 // Continuous discovery sources (postgres-continuous-discovery, patroni-continuous-discovery, patroni-namespace-discovery)
 // will produce multiple monitored databases structs based on the discovered databases.
@@ -99,12 +91,6 @@ type (
 
 	MonitoredDatabases []*MonitoredDatabase
 )
-
-func (md *MonitoredDatabase) Clone() *MonitoredDatabase {
-	// we don't clone the connection and connection config
-	c := &MonitoredDatabase{Source: *md.Source.Clone()}
-	return c
-}
 
 func (md *MonitoredDatabase) Connect(ctx context.Context) (err error) {
 	if md.Conn != nil {

--- a/src/sources/types_test.go
+++ b/src/sources/types_test.go
@@ -64,7 +64,11 @@ func TestMonitoredDatabase_GetDatabaseName(t *testing.T) {
 	md := &sources.MonitoredDatabase{}
 	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
 	expected := "mydatabase"
+	// check pgx.ConnConfig related code
 	got := md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+	// check ConnStr parsing
+	got = md.Source.GetDatabaseName()
 	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
 
 	md = &sources.MonitoredDatabase{}
@@ -73,6 +77,29 @@ func TestMonitoredDatabase_GetDatabaseName(t *testing.T) {
 	got = md.GetDatabaseName()
 	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
 }
+
+func TestMonitoredDatabase_SetDatabaseName(t *testing.T) {
+	md := &sources.MonitoredDatabase{}
+	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
+	expected := "mydatabase"
+	// check ConnStr parsing
+	md.SetDatabaseName(expected)
+	got := md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+	// check pgx.ConnConfig related code
+	expected = "newdatabase"
+	md.SetDatabaseName(expected)
+	got = md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+
+	md = &sources.MonitoredDatabase{}
+	md.ConnStr = "foo boo"
+	expected = ""
+	md.SetDatabaseName("ingored due to invalid ConnStr")
+	got = md.GetDatabaseName()
+	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
+}
+
 func TestMonitoredDatabase_IsPostgresSource(t *testing.T) {
 	md := &sources.MonitoredDatabase{}
 	md.Kind = sources.SourcePostgres

--- a/src/sources/types_test.go
+++ b/src/sources/types_test.go
@@ -61,22 +61,21 @@ func TestMonitoredDatabase_Connect(t *testing.T) {
 	assert.NoError(t, err)
 }
 func TestMonitoredDatabase_GetDatabaseName(t *testing.T) {
-	md := &sources.MonitoredDatabase{
-		ConnStr: "postgres://user:password@localhost:5432/mydatabase",
-	}
+	md := &sources.MonitoredDatabase{}
+	md.ConnStr = "postgres://user:password@localhost:5432/mydatabase"
 	expected := "mydatabase"
 	got := md.GetDatabaseName()
 	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
 
+	md = &sources.MonitoredDatabase{}
 	md.ConnStr = "foo boo"
 	expected = ""
 	got = md.GetDatabaseName()
 	assert.Equal(t, expected, got, "GetDatabaseName() = %v, want %v", got, expected)
 }
 func TestMonitoredDatabase_IsPostgresSource(t *testing.T) {
-	md := &sources.MonitoredDatabase{
-		Kind: sources.SourcePostgres,
-	}
+	md := &sources.MonitoredDatabase{}
+	md.Kind = sources.SourcePostgres
 	assert.True(t, md.IsPostgresSource(), "IsPostgresSource() = false, want true")
 
 	md.Kind = sources.SourcePgBouncer

--- a/src/sources/yaml_test.go
+++ b/src/sources/yaml_test.go
@@ -43,7 +43,7 @@ func TestYAMLGetMonitoredDatabases(t *testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, sampleFile)
 		a.NoError(err)
 
-		dbs, err := yamlrw.GetMonitoredDatabases()
+		dbs, err := yamlrw.GetSources()
 		a.NoError(err)
 		a.Len(dbs, sampleEntriesNumber)
 	})
@@ -52,7 +52,7 @@ func TestYAMLGetMonitoredDatabases(t *testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, currentDir)
 		a.NoError(err)
 
-		dbs, err := yamlrw.GetMonitoredDatabases()
+		dbs, err := yamlrw.GetSources()
 		a.NoError(err)
 		a.Len(dbs, sampleEntriesNumber)
 	})
@@ -60,7 +60,7 @@ func TestYAMLGetMonitoredDatabases(t *testing.T) {
 	t.Run("nonexistent file", func(*testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, "nonexistent.yaml")
 		a.NoError(err)
-		dbs, err := yamlrw.GetMonitoredDatabases()
+		dbs, err := yamlrw.GetSources()
 		a.Error(err)
 		a.Nil(dbs)
 	})
@@ -68,7 +68,7 @@ func TestYAMLGetMonitoredDatabases(t *testing.T) {
 	t.Run("garbage file", func(*testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, filepath.Join(currentDir, "yaml.go"))
 		a.NoError(err)
-		dbs, err := yamlrw.GetMonitoredDatabases()
+		dbs, err := yamlrw.GetSources()
 		a.Error(err)
 		a.Nil(dbs)
 	})
@@ -88,10 +88,10 @@ func TestYAMLDeleteDatabase(t *testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, tmpSampleFile)
 		a.NoError(err)
 
-		err = yamlrw.DeleteDatabase("test1")
+		err = yamlrw.DeleteSource("test1")
 		a.NoError(err)
 
-		dbs, err := yamlrw.GetMonitoredDatabases()
+		dbs, err := yamlrw.GetSources()
 		a.NoError(err)
 		a.Len(dbs, sampleEntriesNumber-1)
 	})
@@ -99,7 +99,7 @@ func TestYAMLDeleteDatabase(t *testing.T) {
 	t.Run("nonexistent file", func(*testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, "nonexistent.yaml")
 		a.NoError(err)
-		err = yamlrw.DeleteDatabase("test1")
+		err = yamlrw.DeleteSource("test1")
 		a.Error(err)
 	})
 }
@@ -119,26 +119,30 @@ func TestYAMLUpdateDatabase(t *testing.T) {
 		a.NoError(err)
 
 		// change the connection string of the first database
-		md := &sources.MonitoredDatabase{DBUniqueName: "test1", ConnStr: "postgresql://localhost/test1"}
-		err = yamlrw.UpdateDatabase(md)
+		md := sources.Source{}
+		md.DBUniqueName = "test1"
+		md.ConnStr = "postgresql://localhost/test1"
+		err = yamlrw.UpdateSource(md)
 		a.NoError(err)
 
 		// add a new database
-		md = &sources.MonitoredDatabase{DBUniqueName: "test5", ConnStr: "postgresql://localhost/test5"}
-		err = yamlrw.UpdateDatabase(md)
+		md = sources.Source{}
+		md.DBUniqueName = "test5"
+		md.ConnStr = "postgresql://localhost/test5"
+		err = yamlrw.UpdateSource(md)
 		a.NoError(err)
 
-		dbs, err := yamlrw.GetMonitoredDatabases()
+		dbs, err := yamlrw.GetSources()
 		a.NoError(err)
 		a.Len(dbs, sampleEntriesNumber+1)
-		dbs.GetMonitoredDatabase("test1").ConnStr = "postgresql://localhost/test1"
-		dbs.GetMonitoredDatabase("test5").ConnStr = "postgresql://localhost/test5"
+		dbs[0].ConnStr = "postgresql://localhost/test1"
+		dbs[sampleEntriesNumber].ConnStr = "postgresql://localhost/test5"
 	})
 
 	t.Run("nonexistent file", func(*testing.T) {
 		yamlrw, err := sources.NewYAMLSourcesReaderWriter(ctx, "")
 		a.NoError(err)
-		err = yamlrw.UpdateDatabase(&sources.MonitoredDatabase{})
+		err = yamlrw.UpdateSource(sources.Source{})
 		a.Error(err)
 	})
 }

--- a/src/webserver/api.go
+++ b/src/webserver/api.go
@@ -67,8 +67,8 @@ func (server *WebUIServer) DeleteMetric(name string) error {
 
 // GetDatabases returns the list of monitored databases
 func (server *WebUIServer) GetDatabases() (res string, err error) {
-	var dbs sources.MonitoredDatabases
-	if dbs, err = server.sourcesReaderWriter.GetMonitoredDatabases(); err != nil {
+	var dbs sources.Sources
+	if dbs, err = server.sourcesReaderWriter.GetSources(); err != nil {
 		return
 	}
 	b, _ := json.Marshal(dbs)
@@ -78,15 +78,15 @@ func (server *WebUIServer) GetDatabases() (res string, err error) {
 
 // DeleteDatabase removes the database from the list of monitored databases
 func (server *WebUIServer) DeleteDatabase(database string) error {
-	return server.sourcesReaderWriter.DeleteDatabase(database)
+	return server.sourcesReaderWriter.DeleteSource(database)
 }
 
 // UpdateDatabase updates the monitored database information
 func (server *WebUIServer) UpdateDatabase(params []byte) error {
-	var md sources.MonitoredDatabase
+	var md sources.Source
 	err := json.Unmarshal(params, &md)
 	if err != nil {
 		return err
 	}
-	return server.sourcesReaderWriter.UpdateDatabase(&md)
+	return server.sourcesReaderWriter.UpdateSource(md)
 }

--- a/src/webserver/api.go
+++ b/src/webserver/api.go
@@ -65,8 +65,8 @@ func (server *WebUIServer) DeleteMetric(name string) error {
 	return server.metricsReaderWriter.DeleteMetric(name)
 }
 
-// GetDatabases returns the list of monitored databases
-func (server *WebUIServer) GetDatabases() (res string, err error) {
+// GetSources returns the list of sources fo find databases for monitoring
+func (server *WebUIServer) GetSources() (res string, err error) {
 	var dbs sources.Sources
 	if dbs, err = server.sourcesReaderWriter.GetSources(); err != nil {
 		return
@@ -76,13 +76,13 @@ func (server *WebUIServer) GetDatabases() (res string, err error) {
 	return
 }
 
-// DeleteDatabase removes the database from the list of monitored databases
-func (server *WebUIServer) DeleteDatabase(database string) error {
+// DeleteSource removes the source from the list of configured sources
+func (server *WebUIServer) DeleteSource(database string) error {
 	return server.sourcesReaderWriter.DeleteSource(database)
 }
 
-// UpdateDatabase updates the monitored database information
-func (server *WebUIServer) UpdateDatabase(params []byte) error {
+// UpdateSource updates the configured source information
+func (server *WebUIServer) UpdateSource(params []byte) error {
 	var md sources.Source
 	err := json.Unmarshal(params, &md)
 	if err != nil {

--- a/src/webserver/source.go
+++ b/src/webserver/source.go
@@ -9,7 +9,7 @@ func (Server *WebUIServer) handleSources(w http.ResponseWriter, r *http.Request)
 	switch r.Method {
 	case http.MethodGet:
 		// return monitored databases
-		dbs, err := Server.GetDatabases()
+		dbs, err := Server.GetSources()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -23,13 +23,13 @@ func (Server *WebUIServer) handleSources(w http.ResponseWriter, r *http.Request)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := Server.UpdateDatabase(p); err != nil {
+		if err := Server.UpdateSource(p); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 
 	case http.MethodDelete:
 		// delete monitored database
-		if err := Server.DeleteDatabase(r.URL.Query().Get("name")); err != nil {
+		if err := Server.DeleteSource(r.URL.Query().Get("name")); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 


### PR DESCRIPTION
**Source** represents a configuration how to get databases to monitor. It can be a single database, a group of databases in postgres cluster, a group of databases in HA patroni cluster.

**MonitoredDatabase** represents a single database to monitor. Unlike source, it means a single physical database connection. Continuous discovery sources (postgres-continuous-discovery, patroni-continuous-discovery, patroni-namespace-discovery) will produce multiple monitored databases.

pgwatch first reads sources (single dbs, postgres and patroni clusters) and then lists all found databases in those as monitored databases