### PR TITLE
[-] fix metric version discovery for old PostgreSQL versions, fixes #489

### DIFF
--- a/src/reaper/file.go
+++ b/src/reaper/file.go
@@ -35,7 +35,7 @@ func IsDirectlyFetchableMetric(metric string) bool {
 	return ok
 }
 
-func FetchStatsDirectlyFromOS(ctx context.Context, msg MetricFetchMessage, vme DBVersionMapEntry, mvp metrics.Metric) ([]metrics.MeasurementMessage, error) {
+func FetchStatsDirectlyFromOS(ctx context.Context, msg MetricFetchConfig, vme MonitoredDatabaseSettings, mvp metrics.Metric) ([]metrics.MeasurementMessage, error) {
 	var data []map[string]any
 	var err error
 
@@ -62,7 +62,7 @@ func FetchStatsDirectlyFromOS(ctx context.Context, msg MetricFetchMessage, vme D
 }
 
 // data + custom tags + counters
-func DatarowsToMetricstoreMessage(data metrics.Measurements, msg MetricFetchMessage, vme DBVersionMapEntry, mvp metrics.Metric) (metrics.MeasurementMessage, error) {
+func DatarowsToMetricstoreMessage(data metrics.Measurements, msg MetricFetchConfig, vme MonitoredDatabaseSettings, mvp metrics.Metric) (metrics.MeasurementMessage, error) {
 	md, err := GetMonitoredDatabaseByUniqueName(msg.DBUniqueName)
 	if err != nil {
 		return metrics.MeasurementMessage{}, err

--- a/src/reaper/recommendations.go
+++ b/src/reaper/recommendations.go
@@ -27,7 +27,7 @@ const (
 var specialMetrics = map[string]bool{recoMetricName: true, specialMetricChangeEvents: true, specialMetricServerLogEventCounts: true}
 var regexIsPgbouncerMetrics = regexp.MustCompile(specialMetricPgbouncer)
 
-func GetAllRecoMetricsForVersion(vme DBVersionMapEntry) (map[string]metrics.Metric, error) {
+func GetAllRecoMetricsForVersion(vme MonitoredDatabaseSettings) (map[string]metrics.Metric, error) {
 	mvpMap := make(map[string]metrics.Metric)
 	metricDefMapLock.RLock()
 	defer metricDefMapLock.RUnlock()
@@ -43,7 +43,7 @@ func GetAllRecoMetricsForVersion(vme DBVersionMapEntry) (map[string]metrics.Metr
 	return mvpMap, nil
 }
 
-func GetRecommendations(ctx context.Context, dbUnique string, vme DBVersionMapEntry) (metrics.Measurements, error) {
+func GetRecommendations(ctx context.Context, dbUnique string, vme MonitoredDatabaseSettings) (metrics.Measurements, error) {
 	retData := make(metrics.Measurements, 0)
 	startTimeEpochNs := time.Now().UnixNano()
 

--- a/src/reaper/types.go
+++ b/src/reaper/types.go
@@ -25,7 +25,7 @@ const (
 
 )
 
-type MetricFetchMessage struct {
+type MetricFetchConfig struct {
 	DBUniqueName        string
 	DBUniqueNameOrig    string
 	MetricName          string
@@ -41,7 +41,7 @@ type ChangeDetectionResults struct { // for passing around DDL/index/config chan
 	Dropped int
 }
 
-type DBVersionMapEntry struct {
+type MonitoredDatabaseSettings struct {
 	LastCheckedOn    time.Time
 	IsInRecovery     bool
 	VersionStr       string


### PR DESCRIPTION
`[*]` rename `DBVersionMapEntry` to `MonitoredDatabaseSettings` 
`[*]` rename `DBGetPGVersion()` to `GetMonitoredDatabaseSettings()` 
`[*]` refactor `GetMonitoredDatabaseSettings()`
`[*]` rename `MetricFetchMessage` to `MetricFetchConfig`