### PR TITLE
[-] fix version detection for pre-16 PostgreSQL, closes #494

### DIFF
--- a/src/reaper/database.go
+++ b/src/reaper/database.go
@@ -226,7 +226,7 @@ func GetMonitoredDatabaseSettings(ctx context.Context, dbUnique string, srcType 
 		dbNewSettings.Version = VersionToInt(matches[0])
 	default:
 		sql := `select /* pgwatch3_generated */ 
-	current_setting('server_version_num')::int / 1_00_00 as ver, 
+	current_setting('server_version_num')::int / 10000 as ver, 
 	version(), 
 	pg_is_in_recovery(), 
 	current_database()::TEXT,


### PR DESCRIPTION
Visual separation of integer using underscores was added in PG16

Fixes #494


Ran it in my lab environment where I have PG14 as source and no errors in log.